### PR TITLE
CSAI fast path: skip backup stream search when all segments are live

### DIFF
--- a/src/modules/processor.ts
+++ b/src/modules/processor.ts
@@ -718,6 +718,19 @@ async function _processM3U8(url, text, realFetch) {
 			startIdx = __TTVAB_STATE__.PlayerReloadMinimalRequestsPlayerIndex;
 		}
 
+		// CSAI fast path: if all segments in the main stream are live,
+		// the ad is CSAI-delivered — no backup stream needed.
+		// Skip backup search to avoid the 20-40s rebuffer gap from stream switching.
+		const mainLines = text.split(/\r?\n/);
+		const hasNonLiveSegment = mainLines.some(
+			(line) => line.startsWith("#EXTINF") && !line.includes(",live"),
+		);
+		if (!hasNonLiveSegment && !info.IsUsingModifiedM3U8) {
+			_log("CSAI fast path — all segments live, skipping backup search", "info");
+			text = _stripAds(text, false, info);
+			return text;
+		}
+
 		const {
 			type: backupType,
 			m3u8: backupM3u8,


### PR DESCRIPTION
  When Twitch delivers ads via CSAI (client-side ad insertion), the ad
  signifiers appear in the m3u8 metadata but all video segments remain
  tagged ',live' — no actual ad segments exist in the playlist.

  Currently, the backup stream search runs on every ad detection
  regardless of delivery method. On CSAI-heavy channels this causes:

  1. Backup stream fetched (50-1000ms)
  2. Backup also has ads (Twitch serves ads across all player types)
  3. Player switches to backup stream then back to main
  4. 20-40s rebuffer gap while player fetches new segments at live position

  This check detects CSAI delivery by scanning #EXTINF lines — if all
  are ',live', no segments need stripping and no backup is needed. Strip
  tracking URLs from the main stream and return directly. The player
  continues playing uninterrupted with zero rebuffer.

  SSAI ads (with non-live segments) fall through to the normal backup
  search and stripping logic unchanged.

ref: https://github.com/ryanbr/TwitchAdSolutions/pull/90 

Could help with https://github.com/GosuDRM/TTV-AB/issues/3