### PR TITLE
Add EXT-X-DATERANGE:CLASS=twitch-trigger (New ad signifier)

### DIFF
--- a/src/modules/parser.ts
+++ b/src/modules/parser.ts
@@ -318,6 +318,7 @@ function _hasExplicitAdMetadata(text) {
 			text.includes("stitched-ad") ||
 			text.includes("/adsquared/") ||
 			text.includes("SCTE35-OUT") ||
+			text.includes('EXT-X-DATERANGE:CLASS="twitch-trigger"') ||
 			text.includes('"MIDROLL"') ||
 			text.includes('"midroll"'))
 	);


### PR DESCRIPTION
  Field evidence (cross-referenced from vaft):                                                                                                                                                                                
  The EXT-X-DATERANGE:CLASS="twitch-trigger" marker has been observed across multiple SSAI-uniform Twitch channels (mande, nicewigg, thatmartinkidtv, fifakillvizualz, warn, slvm, imnio, timthetatman) — always in ad-context
   m3u8s, never observed outside an active ad break. Sibling DATERANGE classes (twitch-session, twitch-stream-source) are session/source metadata and are unrelated.

  This was added to vaft / video-swap-new in https://github.com/ryanbr/TwitchAdSolutions/pull/207 (merged) after several weeks of organic surveillance via a "candidate for future inclusion" diagnostic log. Equivalent fix shape applies cleanly to TTV-AB.

  Test plan that would apply:
                                                                                                                                                                                          
- On a heavy SSAI-uniform channel (warn / mande / etc.), watch through 2-3 ad breaks. Confirm TTV-AB detects ads on poll 1 (no delayed detection on the first ad-cycle poll).
- Watch on a regular Source-clean channel for an hour. Confirm _hasExplicitAdMetadata doesn't fire false positives (no ad-cycle code paths engaging on non-ad streams).