### PR TITLE
feat: ad-completion spoofing with multi-ad pod coverage

### DIFF
--- a/src/modules/api.ts
+++ b/src/modules/api.ts
@@ -317,3 +317,217 @@ async function _getToken(playbackContext, playerType, realFetch) {
 	);
 	return new Response(null, { status: 0 });
 }
+
+// Spoof ad completion to Twitch's GQL endpoint on every ad-laden poll. Twitch's
+// player would normally fire video_ad_impression + 4 quartile_complete +
+// pod_complete beacons as the ad plays. With ad-blocking, those beacons never
+// fire — a fingerprintable signal that may feed Twitch's anti-adblock detection.
+// Spoofing them mimics the "watched the ad" telemetry a normal viewer produces.
+// Multi-ad pods: Twitch reveals each ad's DATERANGE only when that ad starts
+// playing, so a 6-ad pod surfaces ONE ad per m3u8 poll across the break. This
+// runs on every ad-laden poll; info.SpoofedAdIds dedups across polls so each ad
+// is spoofed exactly once as it appears (full N/N pod coverage). pod_complete
+// is sent once per pod (on the ad completing it), not per ad. All events for an
+// ad are sent in one batched POST (Twitch supports JSON-array batched operations
+// natively). Failures swallowed — never blocks ad-block flow.
+async function _notifyAdComplete(
+	textStr: string,
+	info?: { SpoofedAdIds?: Set<string>; ActiveBackupPlayerType?: string | null },
+): Promise<void> {
+	try {
+		if (__TTVAB_STATE__.DisableAdSpoofing) return;
+		if (!textStr || typeof textStr !== "string") return;
+
+		const matches = [
+			...textStr.matchAll(/#EXT-X-DATERANGE:(ID="stitched-ad-[^\n]+)\n/g),
+		];
+		if (matches.length === 0) {
+			if (!__TTVAB_STATE__.LoggedAdSpoofNoMatch) {
+				__TTVAB_STATE__.LoggedAdSpoofNoMatch = true;
+				const dateRangeLine = textStr.match(/#EXT-X-DATERANGE:[^\n]{0,200}/);
+				_log(
+					`notifyAdComplete: no stitched-ad DATERANGE match. Sample DATERANGE: ${dateRangeLine ? dateRangeLine[0] : "none found"}`,
+					"warning",
+				);
+			}
+			return;
+		}
+
+		const spoofedSet = info?.SpoofedAdIds || null;
+		// True pod size from the m3u8 attribute (present on each DATERANGE); fall
+		// back to visible-match count if absent. Keeps total_ads consistent across
+		// all ads in the pod even though they surface one poll at a time.
+		const podLenMatch = textStr.match(/X-TV-TWITCH-AD-POD-LENGTH="(\d+)"/);
+		const podLength = podLenMatch
+			? parseInt(podLenMatch[1], 10)
+			: matches.length;
+		// Hot-path early-out: this runs every ad-laden poll, and a long multi-ad
+		// break has many polls AFTER the whole pod is already spoofed. Once the
+		// dedup set covers the pod, every remaining poll is pure waste — bail
+		// before the per-match parse loop.
+		if (spoofedSet && spoofedSet.size >= podLength) return;
+		let newSpoofed = 0;
+		let firstRollType = "";
+		let podCompleteSent = false;
+
+		for (let i = 0; i < matches.length; i++) {
+			// Cheap ID pre-extract for the dedup check — the DATERANGE capture
+			// always starts with ID="stitched-ad-<UUID>". Checking the dedup set
+			// before the full _parseAttrs() avoids re-parsing every already-
+			// spoofed ad's attribute string on each poll during the spoof phase.
+			const idMatch = matches[i][1].match(/^ID="([^"]+)"/);
+			const stitchedAdId = idMatch ? idMatch[1] : "";
+			// Multi-poll dedup: skip ads already spoofed earlier this break.
+			if (spoofedSet && stitchedAdId && spoofedSet.has(stitchedAdId)) {
+				continue;
+			}
+			const attr = _parseAttrs(matches[i][1]);
+			const radToken = attr["X-TV-TWITCH-AD-RADS-TOKEN"];
+			if (!radToken) {
+				if (i === 0 && !__TTVAB_STATE__.LoggedAdSpoofNoToken) {
+					__TTVAB_STATE__.LoggedAdSpoofNoToken = true;
+					_log(
+						`notifyAdComplete: matched DATERANGE but no RADS token. Attributes: ${Object.keys(attr).join(", ")}`,
+						"warning",
+					);
+				}
+				continue;
+			}
+			const rollType = (attr["X-TV-TWITCH-AD-ROLL-TYPE"] || "").toLowerCase();
+			if (!firstRollType) firstRollType = rollType;
+			// Prefer m3u8's explicit pod-position when present; fall back to index.
+			const adPosition = parseInt(
+				attr["X-TV-TWITCH-AD-POD-POSITION"] || String(i),
+				10,
+			);
+			// Ad's defined duration (X-TV-TWITCH-AD-DURATION is typically a quoted
+			// string in seconds, e.g. "15.000"). parseInt coerces both quoted and
+			// unquoted forms.
+			const adDuration =
+				parseInt(attr["X-TV-TWITCH-AD-DURATION"] || "0", 10) || 0;
+			// Internally-consistent payload: claim "watched the ad normally" which
+			// matches the quartile_complete{4} + pod_complete events we send.
+			// Mismatched fields (mute=true / volume=0 / visible=false / duration=0)
+			// paired with completion events would be an obvious cross-validation
+			// flag if Twitch ever audits.
+			const payload = {
+				stitched: true,
+				ad_id: stitchedAdId,
+				roll_type: rollType,
+				creative_id: attr["X-TV-TWITCH-AD-CREATIVE-ID"] || "",
+				order_id: attr["X-TV-TWITCH-AD-ORDER-ID"] || "",
+				line_item_id: attr["X-TV-TWITCH-AD-LINE-ITEM-ID"] || "",
+				player_mute: false,
+				player_volume: 1.0,
+				visible: true,
+				duration: adDuration,
+				ad_position: adPosition,
+				total_ads: podLength,
+			};
+
+			const makePacket = (event: string, extra?: Record<string, unknown>) => ({
+				operationName: "ClientSideAdEventHandling_RecordAdEvent",
+				variables: {
+					input: {
+						eventName: event,
+						eventPayload: JSON.stringify({ ...payload, ...extra }),
+						radToken,
+					},
+				},
+				extensions: {
+					persistedQuery: {
+						version: 1,
+						sha256Hash:
+							"7e6c69e6eb59f8ccb97ab73686f3d8b7d85a72a0298745ccd8bfc68e4054ca5b",
+					},
+				},
+			});
+
+			// Mark this ad spoofed BEFORE building the batch so the pod-complete
+			// size check below reflects it.
+			if (spoofedSet && stitchedAdId) spoofedSet.add(stitchedAdId);
+			// Batch the events for this ad into one GQL POST.
+			const batch = [
+				makePacket("video_ad_impression"),
+				makePacket("video_ad_quartile_complete", { quartile: 1 }),
+				makePacket("video_ad_quartile_complete", { quartile: 2 }),
+				makePacket("video_ad_quartile_complete", { quartile: 3 }),
+				makePacket("video_ad_quartile_complete", { quartile: 4 }),
+			];
+			// pod_complete fires ONCE per pod — not per ad. A real player sends a
+			// single pod_complete after the whole pod finishes; emitting it on
+			// every ad (6× for a 6-ad pod) is itself a fingerprint. Attach it to
+			// the ad that brings the dedup set up to the true pod size. If the pod
+			// never fully surfaces it is correctly never sent. Defensive fallback
+			// (no dedup set): keep per-ad pod_complete so the signal isn't lost.
+			if (!spoofedSet || spoofedSet.size === podLength) {
+				batch.push(makePacket("video_ad_pod_complete"));
+				podCompleteSent = true;
+			}
+
+			const headers: Record<string, string> = {
+				"Client-ID": _C.CLIENT_ID,
+				"X-Device-Id": __TTVAB_STATE__.GQLDeviceID || "oauth",
+			};
+			if (__TTVAB_STATE__.AuthorizationHeader) {
+				headers.Authorization = __TTVAB_STATE__.AuthorizationHeader;
+			}
+			if (__TTVAB_STATE__.ClientIntegrityHeader) {
+				headers["Client-Integrity"] = __TTVAB_STATE__.ClientIntegrityHeader;
+			}
+			if (__TTVAB_STATE__.ClientVersion) {
+				headers["Client-Version"] = __TTVAB_STATE__.ClientVersion;
+			}
+			if (__TTVAB_STATE__.ClientSession) {
+				headers["Client-Session-Id"] = __TTVAB_STATE__.ClientSession;
+			}
+
+			// Fire-and-forget via the worker bridge. Surveil response status to
+			// detect spoof rejection (400/403/429/5xx) — distinguishes "spoof
+			// accepted" from "spoof rejected/rate-limited." Without this, a Twitch
+			// detection-escalation that starts rejecting our spoofs would be a
+			// silent failure. Once-per-session guard prevents log spam.
+			_fetchViaWorkerBridge(
+				_GQL_URL,
+				{
+					method: "POST",
+					headers,
+					body: JSON.stringify(batch),
+				},
+				5000,
+			)
+				.then((response: Response | null) => {
+					if (
+						response &&
+						response.status !== 200 &&
+						!__TTVAB_STATE__.LoggedAdSpoofBadStatus
+					) {
+						__TTVAB_STATE__.LoggedAdSpoofBadStatus = true;
+						_log(
+							`notifyAdComplete: GQL response status ${response.status} — spoof may be rejected/rate-limited`,
+							"warning",
+						);
+					}
+				})
+				.catch(() => {});
+
+			newSpoofed++;
+		}
+
+		if (newSpoofed > 0) {
+			const total = spoofedSet ? spoofedSet.size : newSpoofed;
+			// src = which stream the spoofed DATERANGEs came from (primary vs a
+			// committed backup player-type) — surfaces the stream-swap ad-ID
+			// mixing limitation. pod-complete = whether this poll attached the
+			// single video_ad_pod_complete.
+			const src = info?.ActiveBackupPlayerType || "primary";
+			_log(
+				`[Trace] Spoofed ad completion for ${newSpoofed} new ad(s) (${total}/${podLength} pod) — roll: ${firstRollType}, src: ${src}, pod-complete: ${podCompleteSent ? "yes" : "no"}`,
+				"info",
+			);
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		_log(`notifyAdComplete failed: ${message}`, "warning");
+	}
+}

--- a/src/modules/hooks.ts
+++ b/src/modules/hooks.ts
@@ -708,6 +708,7 @@ function _hookWorker() {
                 ${_createFetchRelayResponse.toString()}
                 ${_fetchViaWorkerBridge.toString()}
                 ${_getToken.toString()}
+                ${_notifyAdComplete.toString()}
                 ${_getResolvedAdEndMinCleanPlaylists.toString()}
                 ${_getResolvedAdEndGraceMs.toString()}
                 ${_getResolvedAdEndMaxWaitMs.toString()}

--- a/src/modules/processor.ts
+++ b/src/modules/processor.ts
@@ -12,6 +12,7 @@ function _resetStreamAdState(info) {
 	info.IsUsingFallbackStream = false;
 	info.IsUsingBackupStream = false;
 	info.RequestedAds?.clear?.();
+	info.SpoofedAdIds?.clear?.();
 	info.FailedBackupPlayerTypes?.clear?.();
 	info.ActiveBackupPlayerType = null;
 	info.ActiveBackupResolution = null;
@@ -653,6 +654,7 @@ function _createStreamInfo(context) {
 		UsherBaseUrl: "",
 		UsherParams: "",
 		RequestedAds: new Set(),
+		SpoofedAdIds: new Set(),
 		FailedBackupPlayerTypes: new Map(),
 		Urls: Object.create(null),
 		ResolutionList: [],
@@ -919,6 +921,12 @@ async function _processM3U8(url, text, realFetch) {
 	}
 
 	if (hasAds) {
+		// Fire-and-forget GQL ad-tracking spoof on every ad-laden poll. Tells
+		// Twitch the user "watched" the ad (impression/quartile/pod-complete
+		// beacons a real player would send). Twitch surfaces one ad's DATERANGE
+		// per poll in multi-ad pods, so this must run every poll — info.SpoofedAdIds
+		// dedups so each ad is spoofed once (full N/N coverage). See api.ts.
+		_notifyAdComplete(text, info).catch(() => {});
 		if (info.IsHoldingBackupAfterAd) {
 			if (info.LastCleanBackupM3U8) {
 				const now = Date.now();

--- a/src/modules/state.ts
+++ b/src/modules/state.ts
@@ -540,6 +540,10 @@ function _declareState(scope) {
 		PendingFetchRequests: new Map(),
 		FetchRequestSeq: 0,
 		_AdRecoveryConsecutiveFailures: 0,
+		DisableAdSpoofing: false,
+		LoggedAdSpoofNoMatch: false,
+		LoggedAdSpoofNoToken: false,
+		LoggedAdSpoofBadStatus: false,
 	};
 }
 


### PR DESCRIPTION
Adds GQL ad-completion spoofing with full multi-ad pod coverage. Single commit on top of current `main` (v7.7.1).

## Why

Twitch's player normally fires `video_ad_impression` + 4 `video_ad_quartile_complete` + `video_ad_pod_complete` beacons as an ad plays. With ad-blocking those beacons never fire — a clean, fingerprintable "no ad telemetry" signal that may feed anti-adblock detection scoring. Spoofing them mimics the telemetry a normal viewer produces.

## How

- `_notifyAdComplete` fires on **every ad-laden poll** (in the `hasAds` path, passed `info`).
- Twitch reveals each ad's `#EXT-X-DATERANGE` only when that ad starts playing, so a multi-ad pod surfaces **one ad per m3u8 poll**. A per-stream **`SpoofedAdIds`** set (added to `_createStreamInfo`, cleared in `_resetStreamAdState`) dedups across polls keyed on the stitched-ad id → each ad spoofed exactly once → **full N/N pod coverage**.
- `total_ads` from the `X-TV-TWITCH-AD-POD-LENGTH` attribute (true pod size), visible-match fallback.
- `video_ad_pod_complete` fires **once per pod** (on the ad that completes the true pod size), not per ad — per-ad emission is itself a fingerprint; if the pod never fully surfaces it is correctly never sent.
- All events for an ad batched into one POST (Twitch supports JSON-array batched ops). Response status surveilled to detect spoof rejection.
- Hot-path early-out once the pod is covered; cheap `^ID="..."` pre-extract gates the dedup check before `_parseAttrs`.
- Opt out via `__TTVAB_STATE__.DisableAdSpoofing`. Failures swallowed — never blocks the ad-block flow.

## Validation

`npx tsc -p tsconfig.modules.json` clean, `biome check` clean on changed files, `vitest` **58/58** passing on current `main`. The equivalent implementation has been field-validated across 1-ad, 2-ad-with-mid-pod-stream-swap, and 6-ad-with-swap pods — full N/N coverage, single pod_complete per pod, 100% Twitch acceptance (no rejection/rate-limit observed).