### PR TITLE
feat: tolerate TwitchNoSub Worker wrapper for coexistence (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to TTV AB will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Worker-hook coexistence with [TwitchNoSub](https://github.com/besuper/TwitchNoSub) — `_isValid` now accepts wrappers matching an AND-combined signature whitelist, allowing TwitchNoSub to chain on top of TTV-AB's `window.Worker` hook so users can run both extensions simultaneously ([#19](https://github.com/GosuDRM/TTV-AB/issues/19))
+
 ## [9.0.5] - 2026-05-21
 
 ### Fixed

--- a/src/modules/state.ts
+++ b/src/modules/state.ts
@@ -3,7 +3,13 @@
 const _S = {
 	workers: [],
 	conflicts: ["twitch", "isVariantA"],
-	reinsertPatterns: ["isVariantA", "besuper/", "${patch_url}"],
+	reinsertPatterns: ["isVariantA"],
+	toleratedWorkerWrappers: [
+		{
+			name: "TwitchNoSub",
+			signatures: ["${patch_url}", "twitchBlobUrl", "getWasmWorkerJs"],
+		},
+	],
 	adsBlocked: 0,
 };
 const _BRIDGE_PORT_INIT_MESSAGE = "ttvab-bridge-port-init";

--- a/src/modules/worker.ts
+++ b/src/modules/worker.ts
@@ -51,6 +51,13 @@ function _reinsert(W, names) {
 function _isValid(v) {
 	if (typeof v !== "function") return false;
 	const src = v.toString();
+	if (
+		_S.toleratedWorkerWrappers.some((ext) =>
+			ext.signatures.every((sig) => src.includes(sig)),
+		)
+	) {
+		return true;
+	}
 	return (
 		!_S.conflicts.some((c) => src.includes(c)) &&
 		!_S.reinsertPatterns.some((p) => src.includes(p))

--- a/tests/processor-helpers.test.ts
+++ b/tests/processor-helpers.test.ts
@@ -19,7 +19,13 @@ beforeAll(() => {
 	loadModule("../dist/src/modules/processor.js");
 
 	g._log = () => {};
-	g._S = { workers: [], conflicts: [], reinsertPatterns: [], adsBlocked: 0 };
+	g._S = {
+		workers: [],
+		conflicts: [],
+		reinsertPatterns: [],
+		toleratedWorkerWrappers: [],
+		adsBlocked: 0,
+	};
 	g.__TTVAB_STATE__ = {
 		AdSignifier: "stitched",
 		BackupPlayerTypes: ["embed", "popout", "autoplay"],

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -14,7 +14,13 @@ function loadModule(modulePath: string) {
 
 beforeAll(() => {
 	loadModule("../dist/src/modules/constants.js");
-	g._S = { workers: [], conflicts: [], reinsertPatterns: [], adsBlocked: 0 };
+	g._S = {
+		workers: [],
+		conflicts: [],
+		reinsertPatterns: [],
+		toleratedWorkerWrappers: [],
+		adsBlocked: 0,
+	};
 	g._log = () => {};
 	g.__TTVAB_STATE__ = {
 		AdSignifier: "stitched",


### PR DESCRIPTION
## Summary

Allows [TwitchNoSub](https://github.com/besuper/TwitchNoSub) (sub-only VOD bypass) to run alongside TTV-AB by relaxing the `window.Worker` setter rejection — narrowly, via an AND-combined signature whitelist.

Closes #19.

## Why this was blocked before

TTV-AB hooks `window.Worker` first (MAIN world, `run_at: document_start`) and installs a setter that rejects any reassignment whose source matches its conflict/reinsert pattern lists. TwitchNoSub's wrapper class hits **two** rejection rules:

- `"twitch"` — via the `twitchBlobUrl` constructor parameter name (in the `conflicts` list)
- `"${patch_url}"` — via the template literal in TwitchNoSub's blob construction (in the `reinsertPatterns` list)

Net effect: TwitchNoSub's `window.Worker = ...` is silently dropped, its hook never installs, sub-only VODs stay locked.

## The fix

- New `_S.toleratedWorkerWrappers` whitelist. Each entry requires **all** `signatures` strings to be present in the source to match (AND-combined, not OR) — this raises the bar against false positives or accidental masquerade.
- `_isValid` short-circuits `return true` when a tolerated wrapper matches; otherwise unchanged.
- Existing TwitchNoSub markers `"besuper/"` and `"${patch_url}"` removed from `reinsertPatterns` — they were dead as reinsertion candidates (`window["besuper/"]` is undefined; `_reinsert` skips them). Their **only** prior effect was the rejection, which the whitelist now governs.

After the fix, the worker chain forms as:
```
window.Worker → TTV-AB outer hook → TwitchNoSub → native Worker
```
Each layer's `self.fetch` override stacks cleanly inside the worker (TwitchNoSub captured first → installs hook → TTV-AB captured second → wraps TwitchNoSub).

## Why ad-blocking is unaffected

Verified by source-walk that TwitchNoSub's fetch interception scope is **disjoint** from TTV-AB's:

| Surface | TTV-AB | TwitchNoSub |
|---|---|---|
| `usher.ttvnw.net/api/channel/hls/*` (live master) | ✓ | — |
| `usher.ttvnw.net/vod/*` (VOD master) | — | ✓ (only when `status != 200`) |
| `video-weaver.*.hls.ttvnw.net/*` (ad-stitched live) | ✓ | — |
| `cloudfront/*.m3u8` (VOD variants) | — | ✓ (`-unmuted` → `-muted`) |
| `gql.twitch.tv` — `PlaybackAccessToken` | ✓ | — |
| `gql.twitch.tv` — `video(id:)` | — | ✓ (TNS internal) |

TwitchNoSub's normal-VOD path checks `response.status != 200` before faking, so accessible VODs pass through untouched. Live ad-blocking on `video-weaver` URLs is fully isolated from TNS's reach.

## Twitchtheater.tv (multistream) coverage

Both manifests declare `*://*.twitch.tv/*` with `all_frames: true`, so this fix applies automatically inside every `player.twitch.tv` iframe embedded by multistream viewers. No additional changes needed.

## Defense-in-depth on the whitelist

The whitelist requires AND-combination of three distinctive signatures from TwitchNoSub's actual Worker wrapper class:
- `"${patch_url}"` — template-literal interpolation token
- `"twitchBlobUrl"` — parameter name in the constructor
- `"getWasmWorkerJs"` — function reference (originally borrowed from vaft)

Any malicious wrapper attempting to slip through would need to embed all three strings as literals — an unusual fingerprint. If TwitchNoSub renames any of these in a future release, the whitelist can be updated narrowly.

## Files changed

| File | Change |
|---|---|
| `src/modules/state.ts` | Add `toleratedWorkerWrappers`; trim `reinsertPatterns` of dead TNS markers |
| `src/modules/worker.ts` | `_isValid` short-circuits on whitelist match |
| `tests/setup.ts`, `tests/processor-helpers.test.ts` | Forward-compatible stub shape (`toleratedWorkerWrappers: []`) |
| `CHANGELOG.md` | `[Unreleased]` entry |

## Local checks
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (Chrome store zip produced)
- [x] `npm test` — 73/73 passing
- [x] `npm run knip --production` — clean

## Manual smoke-test matrix (recommended pre-merge)

With **both** TTV-AB (this branch) and TwitchNoSub installed:

- [ ] Live channel with mid-roll ad → ad blocked, backup search engages
- [ ] Live channel, ad-free → plays cleanly, no backup engagement
- [ ] Regular non-sub VOD → plays cleanly
- [ ] Sub-only VOD on a channel you don't subscribe to → playback unlocked via TwitchNoSub
- [ ] Channel switch / page navigation → worker restart chain holds
- [ ] Twitchtheater.tv multistream (4 streams, mid-roll on at least one) → all 4 ad-blocked, no cross-frame interference

If any case regresses, the carve-out signatures can be tightened or the fix reverted with a single-file rollback.