### PR TITLE
v9.0.8 — fix consecutive midroll backup contamination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to TTV AB will be documented in this file.
 
+## [9.0.8] - 2026-05-23
+
+### Fixed
+- `_resetStreamAdState` no longer clears `BackupVariantUrls` whitelist on ad-end reset — prevents cached encodings from leaking backup variant URLs and causing backup media playlists to be misidentified as native
+- `_findBackupStream` re-populates `BackupVariantUrls` from cached encodings when reusing a previously fetched master playlist — ensures backup media playlists pass through the `isBackupUrl` gate on consecutive ad breaks
+- Consecutive midroll backup search no longer contaminates `LastCleanNativeM3U8` with backup stream content, fixing stream position corruption on post-reload ad detections
+
 ## [9.0.7] - 2026-05-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # TTV AB
 
-![Version](https://img.shields.io/badge/version-9.0.7-purple)
+![Version](https://img.shields.io/badge/version-9.0.8-purple)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://github.com/GosuDRM/TTV-AB/actions/workflows/ci.yml/badge.svg)
 ![Manifest](https://img.shields.io/badge/manifest-v3-blue)
 ![Firefox](https://img.shields.io/amo/v/ttv-ab-twitch-ad-blocker?label=firefox&color=orange)
-![Chrome](https://img.shields.io/badge/chrome-9.0.7-yellow)
+![Chrome](https://img.shields.io/badge/chrome-9.0.8-yellow)
 [![GitHub](https://img.shields.io/badge/GitHub-TTV--AB-black?logo=github)](https://github.com/GosuDRM/TTV-AB)
 
 A lightweight browser extension that blocks Twitch ads on live streams and VODs while keeping playback stable.
@@ -62,6 +62,9 @@ TTV AB intercepts Twitch's HLS video playlists at the network level. When Twitch
 During ad recovery, Twitch may briefly serve a lower-quality backup stream (e.g. 360p) while the extension keeps playback alive. Your chosen quality is restored automatically once the ad window ends.
 
 ## 🔔 What's New
+
+### v9.0.8 — 2026-05-23
+- Fix consecutive midroll backup contamination: BackupVariantUrls whitelist no longer cleared on ad-end reset, and cached encodings re-populate variant URLs — prevents backup media playlists contaminating native snapshot across ad breaks
 
 ### v9.0.7 — 2026-05-21
 - Buffer monitor throttles to 900ms during steady-state playback — ~33% fewer ticks on healthy streams, stall detection latency unchanged in practice

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"manifest_version": 3,
-	"version": "9.0.7",
+	"version": "9.0.8",
 	"homepage_url": "https://github.com/GosuDRM/TTV-AB",
 	"short_name": "TTV AB",
 	"name": "__MSG_extName__",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ttv-ab",
-  "version": "9.0.7",
+  "version": "9.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ttv-ab",
-    "version": "9.0.7",
+    "version": "9.0.8",
     "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ttv-ab",
-	"version": "9.0.7",
+	"version": "9.0.8",
 	"description": "Twitch Ad Blocker",
 	"license": "MIT",
 	"homepage": "https://github.com/GosuDRM/TTV-AB",

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -1,8 +1,8 @@
 // TTV AB - Constants
 
 const _C = {
-	VERSION: "9.0.7",
-	INTERNAL_VERSION: 189,
+	VERSION: "9.0.8",
+	INTERNAL_VERSION: 190,
 	LOG_STYLES: {
 		prefix:
 			"background: linear-gradient(135deg, #9146FF, #772CE8); color: white; padding: 2px 6px; border-radius: 3px; font-weight: bold;",

--- a/src/modules/processor.ts
+++ b/src/modules/processor.ts
@@ -30,7 +30,6 @@ function _resetStreamAdState(info) {
 	info.HevcReloadPendingAfterHold = false;
 	info.LastAdEndBounceAt = 0;
 	info.LoggedBackupAdsByType = null;
-	info.BackupVariantUrls = new Set();
 	info._BackupSearchStartedAt = 0;
 	info._LastBackupSearchCompletedAt = 0;
 	info._LoggedOfflineTransition = false;
@@ -1810,6 +1809,30 @@ async function _findBackupStream(
 			}
 
 			if (enc) {
+				if (!isFreshM3u8) {
+					const lines = enc.split("\n");
+					for (let i = 0; i < lines.length; i++) {
+						const line = lines[i]?.trim();
+						if (
+							line &&
+							!line.startsWith("#") &&
+							(line.endsWith(".m3u8") || line.includes("://"))
+						) {
+							try {
+								const variantUrl = new URL(line, encBaseUrl).href;
+								info.BackupVariantUrls?.add(variantUrl);
+								for (const alias of _getPlaylistUrlAliases(variantUrl)) {
+									info.BackupVariantUrls?.add(alias);
+								}
+							} catch {}
+						}
+					}
+					while (info.BackupVariantUrls.size > 200) {
+						const first = info.BackupVariantUrls.values().next().value;
+						if (first !== undefined) info.BackupVariantUrls.delete(first);
+						else break;
+					}
+				}
 				try {
 					const streamUrl = _getStreamUrl(enc, targetRes, encBaseUrl);
 					if (streamUrl) {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -998,7 +998,7 @@
         <div class="header-content">
             <div class="title" data-text="TTV AB">TTV AB</div>
             <div class="version-row">
-                <div class="version" id="versionText" aria-label="Version 9.0.7">v9.0.7</div>
+                <div class="version" id="versionText" aria-label="Version 9.0.8">v9.0.8</div>
                 <span class="stable-badge" data-i18n="stable">Stable</span>
             </div>
             <div class="description-text" id="descriptionText">Lightweight, powerful ad blocker designed specifically

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -20,7 +20,7 @@ describe("_C constants", () => {
 	const C = () => g._C as Record<string, unknown>;
 
 	it("has valid version", () => {
-		expect(C().VERSION).toBe("9.0.7");
+		expect(C().VERSION).toBe("9.0.8");
 	});
 
 	it("has positive INTERNAL_VERSION", () => {


### PR DESCRIPTION
## Changes

### Fixed
- **_resetStreamAdState_**: No longer clears BackupVariantUrls whitelist on ad-end reset
- **_findBackupStream_**: Re-populates BackupVariantUrls from cached encodings when reusing a previously fetched master playlist
- Consecutive midroll backup search no longer contaminates LastCleanNativeM3U8 with backup stream content

### Commits
- fix: prevent backup variant URL contamination across ad breaks
- release: v9.0.8 version bump
- docs: v9.0.8 changelog and readme