### PR TITLE
feat: low quality fallback toggle, sub-toggle sync, v9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to TTV AB will be documented in this file.
 
+## [9.1.0] - 2026-05-27
+
+### Added
+- Low quality fallback toggle in popup — allows users to disable autoplay (360p) backup stream with styled warning modal and info tooltip
+- Sub-toggle state sync — ad spoofing and low quality fallback toggles disable when master ad blocking toggle is off
+- Automatic player soft-reload when low quality fallback is disabled while actively streaming from an autoplay backup
+
+### Changed
+- Refined translations across all 11 locales for natural phrasing of adblocking and tech terms
+
+## [9.0.9] - 2026-05-27
+
+### Fixed
+- Backup hold recovery no longer causes A/V desync when autoplay (360p) was the active backup — `HevcReloadPendingAfterHold` now set when backup player type is autoplay, triggering a hard reload with fresh MediaSource on native restoration instead of an in-place stream swap that corrupts the WASM AVC decoder
+- `NativePlaybackRestored` handler passes `newMediaPlayerInstance: true` during autoplay recovery reload, ensuring the WASM worker is torn down and re-initialized on the native source-quality stream
+
 ## [9.0.8] - 2026-05-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # TTV AB
 
-![Version](https://img.shields.io/badge/version-9.0.8-purple)
+![Version](https://img.shields.io/badge/version-9.1.0-purple)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://github.com/GosuDRM/TTV-AB/actions/workflows/ci.yml/badge.svg)
 ![Manifest](https://img.shields.io/badge/manifest-v3-blue)
 ![Firefox](https://img.shields.io/amo/v/ttv-ab-twitch-ad-blocker?label=firefox&color=orange)
-![Chrome](https://img.shields.io/badge/chrome-9.0.8-yellow)
+![Chrome](https://img.shields.io/badge/chrome-9.1.0-yellow)
 [![GitHub](https://img.shields.io/badge/GitHub-TTV--AB-black?logo=github)](https://github.com/GosuDRM/TTV-AB)
 
 A lightweight browser extension that blocks Twitch ads on live streams and VODs while keeping playback stable.
@@ -62,6 +62,14 @@ TTV AB intercepts Twitch's HLS video playlists at the network level. When Twitch
 During ad recovery, Twitch may briefly serve a lower-quality backup stream (e.g. 360p) while the extension keeps playback alive. Your chosen quality is restored automatically once the ad window ends.
 
 ## 🔔 What's New
+
+### v9.1.0 — 2026-05-27
+- New toggle for low quality fallback backup stream with per-locale translations
+- Sub-toggle sync disables spoofer and fallback when master toggle is off
+- Automatic player reload when fallback is disabled while active
+
+### v9.0.9 — 2026-05-27
+- Force player reload with fresh MediaSource when restoring native from autoplay (360p) backup — prevents AVC decoder corruption and audio desync after ad breaks on channels where all source-tier backups are ad-marked
 
 ### v9.0.8 — 2026-05-23
 - Fix consecutive midroll backup contamination: BackupVariantUrls whitelist no longer cleared on ad-end reset, and cached encodings re-populate variant URLs — prevents backup media playlists contaminating native snapshot across ad breaks

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"manifest_version": 3,
-	"version": "9.0.8",
+	"version": "9.1.0",
 	"homepage_url": "https://github.com/GosuDRM/TTV-AB",
 	"short_name": "TTV AB",
 	"name": "__MSG_extName__",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ttv-ab",
-  "version": "9.0.8",
+  "version": "9.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ttv-ab",
-    "version": "9.0.8",
+    "version": "9.1.0",
     "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ttv-ab",
-	"version": "9.0.8",
+	"version": "9.1.0",
 	"description": "Twitch Ad Blocker",
 	"license": "MIT",
 	"homepage": "https://github.com/GosuDRM/TTV-AB",

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -1,8 +1,8 @@
 // TTV AB - Constants
 
 const _C = {
-	VERSION: "9.0.8",
-	INTERNAL_VERSION: 190,
+	VERSION: "9.1.0",
+	INTERNAL_VERSION: 200,
 	LOG_STYLES: {
 		prefix:
 			"background: linear-gradient(135deg, #9146FF, #772CE8); color: white; padding: 2px 6px; border-radius: 3px; font-weight: bold;",

--- a/src/modules/hooks.ts
+++ b/src/modules/hooks.ts
@@ -1332,7 +1332,7 @@ function _hookWorker() {
 								const requiresReload = data.requiresReload === true;
 								_log(
 									requiresReload
-										? "Native playback restored after backup hold; reloading player for HEVC handoff"
+										? "Native playback restored after backup hold; reloading player"
 										: "Native playback restored after backup hold",
 									"success",
 								);
@@ -1344,6 +1344,7 @@ function _hookWorker() {
 										_doPlayerTask(false, true, {
 											reason: "post-ad-native-restore",
 											refreshAccessToken: true,
+											newMediaPlayerInstance: true,
 										});
 									} else {
 										_doPlayerTask(true, false, {

--- a/src/modules/init.ts
+++ b/src/modules/init.ts
@@ -129,6 +129,36 @@ function _initToggleListener() {
 		);
 	});
 
+	_onInternalMessage("ttvab-toggle-autoplay-backup", (detail) => {
+		const safeDetail = _getTrustedBridgeMessageDetail(detail);
+		if (typeof safeDetail?.enabled !== "boolean") return;
+		const enabled = safeDetail.enabled;
+		const shouldDisable = !enabled;
+		if (__TTVAB_STATE__.DisableAutoplayBackup === shouldDisable) return;
+		__TTVAB_STATE__.DisableAutoplayBackup = shouldDisable;
+		_broadcastWorkers({
+			key: "UpdateAutoplayBackupState",
+			value: shouldDisable,
+		});
+		_log(
+			`Low quality fallback ${enabled ? "enabled" : "disabled"}`,
+			enabled ? "success" : "warning",
+		);
+
+		if (
+			shouldDisable &&
+			__TTVAB_STATE__.PinnedBackupPlayerType === "autoplay"
+		) {
+			_log(
+				"Disabling low quality fallback while backup is active; reloading player to restore native high quality stream.",
+				"info",
+			);
+			if (typeof _doPlayerTask === "function") {
+				_doPlayerTask(false, true, { reason: "manual" });
+			}
+		}
+	});
+
 	_onInternalMessage("ttvab-toggle-debug", (detail) => {
 		const safeDetail = _getTrustedBridgeMessageDetail(detail);
 		if (typeof safeDetail?.enabled !== "boolean") return;

--- a/src/modules/player.ts
+++ b/src/modules/player.ts
@@ -176,7 +176,7 @@ let _loggedReactRootSearchFailure = false;
 
 function _findReactRoot() {
 	let rootNode = _cachedReactRootNode;
-	if (!rootNode || !rootNode.isConnected) {
+	if (!rootNode?.isConnected) {
 		rootNode = document.querySelector("#root");
 		if (!rootNode) {
 			_cachedReactRootNode = null;

--- a/src/modules/processor.ts
+++ b/src/modules/processor.ts
@@ -932,7 +932,7 @@ async function _processM3U8(url, text, realFetch) {
 			_rememberLastAdEnd(info, Date.now());
 			_log(
 				requiresReload
-					? "[Trace] Native playlist clean after silent backup hold; reloading player to restore HEVC stream"
+					? "[Trace] Native playlist clean after silent backup hold; reloading player after backup hold"
 					: "[Trace] Native playlist clean after silent backup hold; restoring native stream",
 				"success",
 			);
@@ -1075,7 +1075,8 @@ async function _processM3U8(url, text, realFetch) {
 			info.IsUsingBackupStream = true;
 			info.ActiveBackupPlayerType = heldBackupPlayerType;
 			info.ActiveBackupResolution = res?.Resolution || null;
-			info.HevcReloadPendingAfterHold = heldWasModified;
+			info.HevcReloadPendingAfterHold =
+				heldWasModified || heldBackupPlayerType === "autoplay";
 			_rememberLastAdEnd(info, adEndedAt);
 			__TTVAB_STATE__.CurrentAdChannel = null;
 			__TTVAB_STATE__.CurrentAdMediaKey = null;
@@ -1535,7 +1536,8 @@ async function _processM3U8(url, text, realFetch) {
 			info.IsUsingBackupStream = true;
 			info.ActiveBackupPlayerType = heldBackupPlayerType;
 			info.ActiveBackupResolution = res?.Resolution || null;
-			info.HevcReloadPendingAfterHold = wasUsingModifiedM3U8;
+			info.HevcReloadPendingAfterHold =
+				wasUsingModifiedM3U8 || heldBackupPlayerType === "autoplay";
 		}
 		__TTVAB_STATE__.CurrentAdChannel = null;
 		__TTVAB_STATE__.CurrentAdMediaKey = null;
@@ -1673,7 +1675,11 @@ async function _findBackupStream(
 	const allSourceTypesContaminated =
 		info.LoggedBackupAdsByType &&
 		sourceTypes.every((t) => info.LoggedBackupAdsByType.has(t));
-	if (allSourceTypesContaminated && !playerTypes.includes("autoplay")) {
+	if (
+		allSourceTypesContaminated &&
+		!playerTypes.includes("autoplay") &&
+		!__TTVAB_STATE__.DisableAutoplayBackup
+	) {
 		playerTypes.push("autoplay");
 	}
 	const playerTypesLen = playerTypes.length;

--- a/src/modules/state.ts
+++ b/src/modules/state.ts
@@ -547,6 +547,7 @@ function _declareState(scope) {
 		FetchRequestSeq: 0,
 		_AdRecoveryConsecutiveFailures: 0,
 		DisableAdSpoofing: false,
+		DisableAutoplayBackup: false,
 		LoggedAdSpoofNoMatch: false,
 		LoggedAdSpoofNoToken: false,
 		LoggedAdSpoofBadStatus: false,

--- a/src/modules/worker.ts
+++ b/src/modules/worker.ts
@@ -58,8 +58,14 @@ function _isValid(v) {
 	) {
 		return true;
 	}
-	return (
-		!_S.conflicts.some((c) => src.includes(c)) &&
-		!_S.reinsertPatterns.some((p) => src.includes(p))
-	);
+	const hasConflict = _S.conflicts.some((c) => src.includes(c));
+	const hasReinsert = _S.reinsertPatterns.some((p) => src.includes(p));
+	if (hasConflict) {
+		const matched = _S.conflicts.filter((c) => src.includes(c));
+		_log(
+			`Worker wrapper rejected (conflict: ${matched.join(", ")}, hasReinsert: ${hasReinsert})`,
+			"debug",
+		);
+	}
+	return !hasConflict && !hasReinsert;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -624,6 +624,7 @@
         }
 
         .info {
+            display: none;
             margin-top: 16px;
             text-align: center;
             font-size: 11px;
@@ -998,7 +999,7 @@
         <div class="header-content">
             <div class="title" data-text="TTV AB">TTV AB</div>
             <div class="version-row">
-                <div class="version" id="versionText" aria-label="Version 9.0.8">v9.0.8</div>
+                <div class="version" id="versionText" aria-label="Version 9.1.0">v9.1.0</div>
                 <span class="stable-badge" data-i18n="stable">Stable</span>
             </div>
             <div class="description-text" id="descriptionText">Lightweight, powerful ad blocker designed specifically
@@ -1126,16 +1127,18 @@
                 <label class="toggle-label" for="adSpoofingToggle" data-i18n="adSpoofing">Ad Spoofing</label>
                 <span class="info-icon" id="adSpoofingInfoIcon" aria-label="What is Ad Spoofing?">i</span>
             </div>
-            <div class="modal-overlay" id="adSpoofingTooltip" hidden>
-                <div class="modal-box">
-                    <p><strong data-i18n="adSpoofing">Ad Spoofing</strong></p>
-                    <p data-i18n="adSpoofingDesc">Sends fake ad-watch beacons to Twitch to reduce anti-adblock fingerprinting. May interfere with channel points collection on some accounts.</p>
-                    <p data-i18n="adSpoofingFootnote">Disable if you experience issues claiming channel points.</p>
-                    <button type="button" class="modal-close" id="adSpoofingModalClose" data-i18n="adSpoofingGotIt">Got it</button>
-                </div>
-            </div>
             <label class="toggle">
                 <input type="checkbox" id="adSpoofingToggle" checked aria-label="Ad Spoofing">
+                <span class="slider"></span>
+            </label>
+        </div>
+        <div class="toggle-row">
+            <div class="toggle-label-row">
+                <label class="toggle-label" for="autoplayBackupToggle" data-i18n="autoplayBackup">Low Quality Fallback</label>
+                <span class="info-icon" id="autoplayBackupInfoIcon" aria-label="About Low Quality Fallback">i</span>
+            </div>
+            <label class="toggle">
+                <input type="checkbox" id="autoplayBackupToggle" checked aria-label="Low Quality Fallback">
                 <span class="slider"></span>
             </label>
         </div>
@@ -1174,6 +1177,25 @@
                 AB</a><span id="footerText"> — by </span><a href="https://github.com/GosuDRM" target="_blank"
                 rel="noopener noreferrer" id="authorLink" class="author-link" title="Open GosuDRM on GitHub"
                 aria-label="Open GosuDRM on GitHub">GosuDRM</a></span>
+    </div>
+
+    <!-- Modals at root level to prevent overflow clipping by container and flexbox positioning bugs -->
+    <div class="modal-overlay" id="adSpoofingTooltip" hidden>
+        <div class="modal-box">
+            <p><strong data-i18n="adSpoofing">Ad Spoofing</strong></p>
+            <p data-i18n="adSpoofingDesc">Sends fake ad-watch beacons to Twitch to reduce anti-adblock fingerprinting. May interfere with channel points collection on some accounts.</p>
+            <p data-i18n="adSpoofingFootnote">Disable if you experience issues claiming channel points.</p>
+            <button type="button" class="modal-close" id="adSpoofingModalClose" data-i18n="adSpoofingGotIt">Got it</button>
+        </div>
+    </div>
+
+    <div class="modal-overlay" id="autoplayBackupTooltip" hidden>
+        <div class="modal-box">
+            <p><strong data-i18n="autoplayBackup">Low Quality Fallback</strong></p>
+            <p data-i18n="autoplayBackupDesc">Uses a lower resolution backup stream when no high quality source is ad-free. Keeps playback smooth at reduced quality during ads.</p>
+            <p data-i18n="autoplayBackupWarning">Disabling may cause a black screen or frozen video during ads on some channels.</p>
+            <button type="button" class="modal-close" id="autoplayBackupModalClose" data-i18n="autoplayBackupGotIt">Got it</button>
+        </div>
     </div>
 
     <script src="translations.js"></script>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -56,6 +56,9 @@ document.addEventListener("DOMContentLoaded", () => {
 	const adSpoofingToggle = document.getElementById(
 		"adSpoofingToggle",
 	) as HTMLInputElement | null;
+	const autoplayBackupToggle = document.getElementById(
+		"autoplayBackupToggle",
+	) as HTMLInputElement | null;
 	const donateButton = document.getElementById(
 		"donateBtn",
 	) as HTMLAnchorElement | null;
@@ -90,6 +93,7 @@ document.addEventListener("DOMContentLoaded", () => {
 		footerText,
 		infoText,
 		adSpoofingToggle,
+		autoplayBackupToggle,
 		donateButton,
 		repoLink,
 		authorLink,
@@ -756,7 +760,12 @@ document.addEventListener("DOMContentLoaded", () => {
 	}
 
 	chrome.storage.local.get(
-		["ttvAdblockEnabled", "ttvAdSpoofingEnabled", "ttvAdsBlocked"],
+		[
+			"ttvAdblockEnabled",
+			"ttvAdSpoofingEnabled",
+			"ttvAutoplayBackupEnabled",
+			"ttvAdsBlocked",
+		],
 		(result) => {
 			if (chrome.runtime.lastError) {
 				console.error(
@@ -767,9 +776,13 @@ document.addEventListener("DOMContentLoaded", () => {
 			const safeResult = (result || {}) as PlainObject;
 			const enabled = safeResult.ttvAdblockEnabled !== false;
 			const adSpoofingEnabled = safeResult.ttvAdSpoofingEnabled !== false;
+			const autoplayBackupEnabled =
+				safeResult.ttvAutoplayBackupEnabled !== false;
 			toggle.checked = enabled;
 			adSpoofingToggle.checked = adSpoofingEnabled;
+			autoplayBackupToggle.checked = autoplayBackupEnabled;
 			updateStatus(enabled, false);
+			syncSubTogglesState(enabled);
 
 			const adsCount = normalizeCount(safeResult.ttvAdsBlocked);
 			adsBlockedCount.textContent = formatNumber(adsCount);
@@ -785,10 +798,16 @@ document.addEventListener("DOMContentLoaded", () => {
 			const enabled = changes.ttvAdblockEnabled.newValue !== false;
 			toggle.checked = enabled;
 			updateStatus(enabled, false);
+			syncSubTogglesState(enabled);
 		}
 		if (changes.ttvAdSpoofingEnabled) {
-			const adSpoofingEnabled = changes.ttvAdSpoofingEnabled.newValue === true;
+			const adSpoofingEnabled = changes.ttvAdSpoofingEnabled.newValue !== false;
 			adSpoofingToggle.checked = adSpoofingEnabled;
+		}
+		if (changes.ttvAutoplayBackupEnabled) {
+			const autoplayBackupEnabled =
+				changes.ttvAutoplayBackupEnabled.newValue !== false;
+			autoplayBackupToggle.checked = autoplayBackupEnabled;
 		}
 		if (changes.ttvAdsBlocked) {
 			const newCount = normalizeCount(changes.ttvAdsBlocked.newValue);
@@ -799,6 +818,35 @@ document.addEventListener("DOMContentLoaded", () => {
 			loadStatistics();
 		}
 	});
+
+	function syncSubTogglesState(adblockEnabled: boolean) {
+		if (adSpoofingToggle) {
+			adSpoofingToggle.disabled = !adblockEnabled;
+			const label = adSpoofingToggle
+				.closest(".toggle-row")
+				?.querySelector(".toggle-label");
+			const slider = adSpoofingToggle
+				.closest(".toggle-row")
+				?.querySelector(".slider");
+			if (label)
+				(label as HTMLElement).style.opacity = adblockEnabled ? "1" : "0.4";
+			if (slider)
+				(slider as HTMLElement).style.opacity = adblockEnabled ? "1" : "0.4";
+		}
+		if (autoplayBackupToggle) {
+			autoplayBackupToggle.disabled = !adblockEnabled;
+			const label = autoplayBackupToggle
+				.closest(".toggle-row")
+				?.querySelector(".toggle-label");
+			const slider = autoplayBackupToggle
+				.closest(".toggle-row")
+				?.querySelector(".slider");
+			if (label)
+				(label as HTMLElement).style.opacity = adblockEnabled ? "1" : "0.4";
+			if (slider)
+				(slider as HTMLElement).style.opacity = adblockEnabled ? "1" : "0.4";
+		}
+	}
 
 	let toggleWriteInFlight = false;
 
@@ -818,9 +866,11 @@ document.addEventListener("DOMContentLoaded", () => {
 				);
 				toggle.checked = previousEnabled;
 				updateStatus(previousEnabled);
+				syncSubTogglesState(previousEnabled);
 				return;
 			}
 			updateStatus(enabled, true);
+			syncSubTogglesState(enabled);
 		});
 	});
 
@@ -831,9 +881,14 @@ document.addEventListener("DOMContentLoaded", () => {
 	if (adSpoofingInfoIcon && adSpoofingTooltip) {
 		adSpoofingInfoIcon.addEventListener("click", (e) => {
 			e.stopPropagation();
-			const show = adSpoofingTooltip.hasAttribute("hidden");
-			adSpoofingTooltip.hidden = false;
-			adSpoofingTooltip.classList.toggle("visible", show);
+			const isVisible = adSpoofingTooltip.classList.contains("visible");
+			if (isVisible) {
+				adSpoofingTooltip.hidden = true;
+				adSpoofingTooltip.classList.remove("visible");
+			} else {
+				adSpoofingTooltip.hidden = false;
+				adSpoofingTooltip.classList.add("visible");
+			}
 		});
 		adSpoofingTooltip.addEventListener("click", (e) => {
 			if (e.target === adSpoofingTooltip) {
@@ -871,6 +926,119 @@ document.addEventListener("DOMContentLoaded", () => {
 			updateStatus(enabled, true, "adSpoofing");
 		});
 	});
+
+	let autoplayBackupWriteInFlight = false;
+	let bypassAutoplayBackupWarning = false;
+	let isAutoplayBackupWarningContext = false;
+
+	const autoplayBackupInfoIcon = document.getElementById(
+		"autoplayBackupInfoIcon",
+	);
+	const autoplayBackupTooltip = document.getElementById(
+		"autoplayBackupTooltip",
+	);
+	if (autoplayBackupInfoIcon && autoplayBackupTooltip) {
+		autoplayBackupInfoIcon.addEventListener("click", (e) => {
+			e.stopPropagation();
+			const isVisible = autoplayBackupTooltip.classList.contains("visible");
+			console.log(
+				"[TTV AB] Autoplay backup info icon clicked. Current visible state:",
+				isVisible,
+			);
+			if (isVisible) {
+				autoplayBackupTooltip.hidden = true;
+				autoplayBackupTooltip.classList.remove("visible");
+			} else {
+				isAutoplayBackupWarningContext = false;
+				autoplayBackupTooltip.hidden = false;
+				autoplayBackupTooltip.classList.add("visible");
+			}
+		});
+		autoplayBackupTooltip.addEventListener("click", (e) => {
+			if (e.target === autoplayBackupTooltip) {
+				console.log(
+					"[TTV AB] Autoplay backup tooltip overlay clicked (outside modal box)",
+				);
+				autoplayBackupTooltip.hidden = true;
+				autoplayBackupTooltip.classList.remove("visible");
+			}
+		});
+	}
+
+	if (autoplayBackupToggle) {
+		autoplayBackupToggle.addEventListener("change", () => {
+			console.log(
+				"[TTV AB] Autoplay backup toggle change event. checked:",
+				autoplayBackupToggle.checked,
+				"bypass flag:",
+				bypassAutoplayBackupWarning,
+			);
+			if (autoplayBackupWriteInFlight) return;
+			const disabling = !autoplayBackupToggle.checked;
+			if (disabling && !bypassAutoplayBackupWarning) {
+				console.log("[TTV AB] Disabling detected, prompting warning modal");
+				autoplayBackupToggle.checked = true;
+				if (autoplayBackupTooltip) {
+					isAutoplayBackupWarningContext = true;
+					autoplayBackupTooltip.hidden = false;
+					autoplayBackupTooltip.classList.add("visible");
+					console.log(
+						"[TTV AB] Modal overlay shown successfully. visible class present:",
+						autoplayBackupTooltip.classList.contains("visible"),
+					);
+				} else {
+					console.error(
+						"[TTV AB] Autoplay backup tooltip modal element not found in DOM",
+					);
+				}
+				return;
+			}
+			bypassAutoplayBackupWarning = false;
+			autoplayBackupWriteInFlight = true;
+			autoplayBackupToggle.disabled = true;
+			const enabled = autoplayBackupToggle.checked;
+			const previousEnabled = !enabled;
+			console.log(
+				"[TTV AB] Saving autoplay backup status to local storage:",
+				enabled,
+			);
+			chrome.storage.local.set({ ttvAutoplayBackupEnabled: enabled }, () => {
+				autoplayBackupWriteInFlight = false;
+				autoplayBackupToggle.disabled = false;
+				if (chrome.runtime.lastError) {
+					console.error(
+						"[TTV AB] Popup autoplay backup toggle write error:",
+						chrome.runtime.lastError.message,
+					);
+					autoplayBackupToggle.checked = previousEnabled;
+					updateStatus(previousEnabled, false, "autoplayBackup");
+					return;
+				}
+				console.log("[TTV AB] Storage write success. New state:", enabled);
+				updateStatus(enabled, true, "autoplayBackup");
+			});
+		});
+
+		const autoplayBackupModalClose = document.getElementById(
+			"autoplayBackupModalClose",
+		);
+		if (autoplayBackupModalClose && autoplayBackupTooltip) {
+			autoplayBackupModalClose.addEventListener("click", () => {
+				console.log(
+					"[TTV AB] Got It modal button clicked. Warning context:",
+					isAutoplayBackupWarningContext,
+				);
+				autoplayBackupTooltip.hidden = true;
+				autoplayBackupTooltip.classList.remove("visible");
+				if (isAutoplayBackupWarningContext && autoplayBackupToggle.checked) {
+					bypassAutoplayBackupWarning = true;
+					autoplayBackupToggle.checked = false;
+					autoplayBackupToggle.dispatchEvent(new Event("change"));
+				}
+				isAutoplayBackupWarningContext = false;
+			});
+		}
+	}
 
 	function parseTransitionTimeToMs(value) {
 		const trimmedValue = String(value || "").trim();
@@ -1013,10 +1181,14 @@ document.addEventListener("DOMContentLoaded", () => {
 			infoText.style.color = "#666";
 			return;
 		}
-		const label =
-			transientStatusType === "adSpoofing"
-				? translations.adSpoofing
-				: translations.adBlocking;
+		let label = "";
+		if (transientStatusType === "adSpoofing") {
+			label = translations.adSpoofing;
+		} else if (transientStatusType === "autoplayBackup") {
+			label = translations.autoplayBackup;
+		} else {
+			label = translations.adBlocking;
+		}
 		infoText.textContent = `${label}: ${transientStatusState ? translations.active : translations.inactive}`;
 		infoText.style.color = transientStatusState ? "#4CAF50" : "#f44336";
 	}

--- a/src/popup/translations.ts
+++ b/src/popup/translations.ts
@@ -24,6 +24,12 @@ const TRANSLATIONS = {
 			"Sends ad-watch signals to Twitch to reduce anti-adblock detection.",
 		adSpoofingFootnote: "Disable if you experience issues.",
 		adSpoofingGotIt: "Got it",
+		autoplayBackup: "Low Quality Fallback",
+		autoplayBackupDesc:
+			"Switches to a lower resolution backup when no ad-free high quality stream is available. Keeps playback smooth at 360p during ads.",
+		autoplayBackupWarning:
+			"Disabling may cause a black screen or frozen video during ads on channels where all high quality sources carry ads.",
+		autoplayBackupGotIt: "Got it",
 		stable: "Stable",
 		changesInstantly: "Changes take effect instantly",
 		noDataYet: "No data yet",
@@ -78,7 +84,7 @@ const TRANSLATIONS = {
 		adBlocking: "Bloqueo de anuncios",
 		bufferFix: "Corrección de búfer",
 		bufferFixDesc:
-			"Detecta y recupera de congelamientos, pantallas negras tras anuncios, retraso en directo y desincronización de audio/vídeo.",
+			"Detecta y soluciona congelaciones, pantallas negras tras anuncios, retrasos en la transmisión y desincronización de audio/video.",
 		bufferFixFootnote: "Desactívalo solo si tienes problemas.",
 		bufferFixGotIt: "Entendido",
 		adSpoofing: "Suplantación de anuncios",
@@ -86,6 +92,12 @@ const TRANSLATIONS = {
 			"Envía señales de visualización de anuncios a Twitch para reducir la detección del bloqueo de anuncios.",
 		adSpoofingFootnote: "Desactívalo si tienes problemas.",
 		adSpoofingGotIt: "Entendido",
+		autoplayBackup: "Respaldo de baja calidad",
+		autoplayBackupDesc:
+			"Cambia a un flujo de respaldo de menor resolución cuando no hay una fuente de alta calidad sin anuncios. Mantiene la reproducción fluida a 360p durante los anuncios.",
+		autoplayBackupWarning:
+			"Desactivarlo puede causar pantalla negra o video congelado durante los anuncios en canales donde todas las fuentes de alta calidad tienen anuncios.",
+		autoplayBackupGotIt: "Entendido",
 		stable: "Estable",
 		changesInstantly: "Los cambios se aplican al instante",
 		noDataYet: "Aún no hay datos",
@@ -114,11 +126,11 @@ const TRANSLATIONS = {
 			block_5000: { name: "Mítico", desc: "¡Has bloqueado 5000 anuncios!" },
 			time_1h: {
 				name: "Ahorrador de tiempo",
-				desc: "¡Has ahorrado 1 hora de anuncios!",
+				desc: "¡Has evitado 1 hora de anuncios!",
 			},
 			time_10h: {
 				name: "Maestro del tiempo",
-				desc: "¡Has ahorrado 10 horas de anuncios!",
+				desc: "¡Has evitado 10 horas de anuncios!",
 			},
 			channels_5: {
 				name: "Explorador",
@@ -160,6 +172,12 @@ const TRANSLATIONS = {
 			"Envoie des signaux de visionnage de pubs à Twitch pour réduire la détection du bloqueur de pubs.",
 		adSpoofingFootnote: "Désactivez en cas de problème.",
 		adSpoofingGotIt: "Compris",
+		autoplayBackup: "Secours basse qualité",
+		autoplayBackupDesc:
+			"Passe à un flux de secours de résolution inférieure lorsqu'aucune source haute qualité sans publicité n'est disponible. Maintient une lecture fluide à 360p pendant les publicités.",
+		autoplayBackupWarning:
+			"La désactivation peut entraîner un écran noir ou une vidéo figée pendant les publicités sur les chaînes où toutes les sources haute qualité diffusent des publicités.",
+		autoplayBackupGotIt: "Compris",
 		stable: "Stable",
 		changesInstantly: "Les changements s'appliquent instantanément",
 		noDataYet: "Pas encore de données",
@@ -232,14 +250,20 @@ const TRANSLATIONS = {
 		adBlocking: "Werbeblockierung",
 		bufferFix: "Puffer-Fix",
 		bufferFixDesc:
-			"Erkennt und behebt Wiedergabefehler, schwarze Bildschirme nach Werbung, Live-Verzögerungen und Ton/Bild-Versatz.",
+			"Erkennt und behebt Wiedergabe-Aussetzer, schwarze Bildschirme nach Werbung, Live-Verzögerungen und Ton/Bild-Versatz.",
 		bufferFixFootnote: "Nur deaktivieren, wenn es Probleme gibt.",
 		bufferFixGotIt: "Verstanden",
-		adSpoofing: "Werbe-Täuschung",
+		adSpoofing: "Werbe-Spoofing",
 		adSpoofingDesc:
 			"Sendet Werbe-Signale an Twitch, um die Erkennung des Werbeblockers zu erschweren.",
 		adSpoofingFootnote: "Deaktiviere es bei Problemen.",
 		adSpoofingGotIt: "Verstanden",
+		autoplayBackup: "Qualitäts-Fallback",
+		autoplayBackupDesc:
+			"Wechselt zu einem Backup-Stream mit niedrigerer Auflösung, wenn keine werbefreie hochauflösende Quelle verfügbar ist. Hält die Wiedergabe bei 360p während der Werbung flüssig.",
+		autoplayBackupWarning:
+			"Deaktivierung kann zu schwarzem Bildschirm oder eingefrorenem Video während der Werbung auf Kanälen führen, bei denen alle hochauflösenden Quellen Werbung enthalten.",
+		autoplayBackupGotIt: "Verstanden",
 		stable: "Stabil",
 		changesInstantly: "Änderungen werden sofort übernommen",
 		noDataYet: "Noch keine Daten",
@@ -321,7 +345,7 @@ const TRANSLATIONS = {
 		adBlocking: "Bloqueio de anúncios",
 		bufferFix: "Correção de buffer",
 		bufferFixDesc:
-			"Detecta e recupera de travamentos, telas pretas pós-anúncio, atraso no ao vivo e dessincronização de áudio/vídeo.",
+			"Detecta e recupera de travamentos, telas pretas pós-anúncio, atraso na transmissão e dessincronização de áudio/vídeo.",
 		bufferFixFootnote: "Desative apenas se tiver problemas.",
 		bufferFixGotIt: "Entendi",
 		adSpoofing: "Simulação de anúncios",
@@ -329,8 +353,14 @@ const TRANSLATIONS = {
 			"Envia sinais de visualização de anúncios ao Twitch para reduzir a detecção do bloqueador.",
 		adSpoofingFootnote: "Desative se tiver problemas.",
 		adSpoofingGotIt: "Entendi",
+		autoplayBackup: "Reserva de baixa qualidade",
+		autoplayBackupDesc:
+			"Alterna para um fluxo de reserva de resolução mais baixa quando nenhuma fonte de alta qualidade sem anúncios está disponível. Mantém a reprodução suave a 360p durante os anúncios.",
+		autoplayBackupWarning:
+			"Desativar pode causar tela preta ou vídeo congelado durante os anúncios em canais onde todas as fontes de alta qualidade têm anúncios.",
+		autoplayBackupGotIt: "Entendi",
 		stable: "Estável",
-		changesInstantly: "As alterações entram em vigor na hora",
+		changesInstantly: "As alterações entram em vigor imediatamente",
 		noDataYet: "Ainda não há dados",
 		allUnlocked: "Tudo desbloqueado!",
 		next: "Próximo",
@@ -357,11 +387,11 @@ const TRANSLATIONS = {
 			block_5000: { name: "Mítico", desc: "Você bloqueou 5000 anúncios!" },
 			time_1h: {
 				name: "Poupador de tempo",
-				desc: "Você economizou 1 hora de anúncios!",
+				desc: "Você evitou 1 hora de anúncios!",
 			},
 			time_10h: {
 				name: "Mestre do tempo",
-				desc: "Você economizou 10 horas de anúncios!",
+				desc: "Você evitou 10 horas de anúncios!",
 			},
 			channels_5: {
 				name: "Explorador",
@@ -403,6 +433,12 @@ const TRANSLATIONS = {
 			"Invia segnali di visualizzazione annunci a Twitch per ridurre il rilevamento dell'ad blocker.",
 		adSpoofingFootnote: "Disattiva in caso di problemi.",
 		adSpoofingGotIt: "Capito",
+		autoplayBackup: "Riserva a bassa qualità",
+		autoplayBackupDesc:
+			"Passa a un flusso di riserva a risoluzione inferiore quando nessuna fonte di alta qualità senza pubblicità è disponibile. Mantiene la riproduzione fluida a 360p durante gli annunci.",
+		autoplayBackupWarning:
+			"La disattivazione potrebbe causare schermo nero o video bloccato durante gli annunci sui canali in cui tutte le fonti di alta qualità contengono pubblicità.",
+		autoplayBackupGotIt: "Capito",
 		stable: "Stabile",
 		changesInstantly: "Le modifiche hanno effetto immediato",
 		noDataYet: "Ancora nessun dato",
@@ -431,11 +467,11 @@ const TRANSLATIONS = {
 			block_5000: { name: "Mitico", desc: "Hai bloccato 5000 annunci!" },
 			time_1h: {
 				name: "Salva-tempo",
-				desc: "Hai risparmiato 1 ora di annunci!",
+				desc: "Hai evitato 1 ora di annunci!",
 			},
 			time_10h: {
 				name: "Maestro del tempo",
-				desc: "Hai risparmiato 10 ore di annunci!",
+				desc: "Hai evitato 10 ore di annunci!",
 			},
 			channels_5: {
 				name: "Esploratore",
@@ -460,7 +496,7 @@ const TRANSLATIONS = {
 		active: "有効",
 		inactive: "無効",
 		adsBlocked: "ブロックした広告",
-		timeSaved: "節約できた時間",
+		timeSaved: "節約した時間",
 		statistics: "統計",
 		last7Days: "今週",
 		topChannels: "上位チャンネル",
@@ -477,6 +513,12 @@ const TRANSLATIONS = {
 			"広告ブロックの検出を回避するため、広告を視聴したという信号をTwitchに送信します。",
 		adSpoofingFootnote: "問題がある場合は無効にしてください。",
 		adSpoofingGotIt: "了解",
+		autoplayBackup: "低画質フォールバック",
+		autoplayBackupDesc:
+			"広告なしの高画質ソースが利用できない場合、低解像度のバックアップストリームに切り替えます。広告中も360pでスムーズな再生を維持します。",
+		autoplayBackupWarning:
+			"無効にすると、すべての高画質ソースに広告が含まれるチャンネルで、広告中に黒画面や映像のフリーズが発生する可能性があります。",
+		autoplayBackupGotIt: "了解",
 		stable: "安定版",
 		changesInstantly: "変更はすぐに反映されます",
 		noDataYet: "まだデータがありません",
@@ -561,7 +603,13 @@ const TRANSLATIONS = {
 		adSpoofingDesc:
 			"광고 차단 탐지를 줄이기 위해 광고 시청 신호를 Twitch에 보냅니다.",
 		adSpoofingFootnote: "문제가 있으면 비활성화하세요.",
-		adSpoofingGotIt: "알겠습니다",
+		adSpoofingGotIt: "확인",
+		autoplayBackup: "저화질 폴백",
+		autoplayBackupDesc:
+			"광고 없는 고화질 소스를 사용할 수 없을 때 저해상도 백업 스트림으로 전환합니다. 광고 중에도 360p로 부드러운 재생을 유지합니다.",
+		autoplayBackupWarning:
+			"비활성화하면 모든 고화질 소스에 광고가 포함된 채널에서 광고 중에 검은 화면이나 동영상 정지가 발생할 수 있습니다.",
+		autoplayBackupGotIt: "확인",
 		stable: "안정판",
 		changesInstantly: "변경 사항이 즉시 적용됩니다",
 		noDataYet: "아직 데이터가 없습니다",
@@ -624,6 +672,12 @@ const TRANSLATIONS = {
 		adSpoofingDesc: "向 Twitch 发送广告观看信标，以减少广告拦截器的检测。",
 		adSpoofingFootnote: "如遇到问题，请禁用此功能。",
 		adSpoofingGotIt: "知道了",
+		autoplayBackup: "低画质备选流",
+		autoplayBackupDesc:
+			"当没有无广告的高画质源时，切换到低分辨率备选流。在广告期间保持360p流畅播放。",
+		autoplayBackupWarning:
+			"关闭后，在所有高画质源都带有广告的频道上，广告期间可能出现黑屏或画面冻结。",
+		autoplayBackupGotIt: "知道了",
 		stable: "稳定版",
 		changesInstantly: "更改会立即生效",
 		noDataYet: "暂无数据",
@@ -675,6 +729,12 @@ const TRANSLATIONS = {
 		adSpoofingDesc: "向 Twitch 傳送廣告觀看訊號，以減少廣告攔截器的偵測。",
 		adSpoofingFootnote: "如遇到問題，請停用此功能。",
 		adSpoofingGotIt: "知道了",
+		autoplayBackup: "低畫質備選串流",
+		autoplayBackupDesc:
+			"當沒有無廣告的高畫質來源時，切換到低解析度備選串流。在廣告期間保持360p流暢播放。",
+		autoplayBackupWarning:
+			"關閉後，在所有高畫質來源都帶有廣告的頻道上，廣告期間可能出現黑畫面或畫面凍結。",
+		autoplayBackupGotIt: "知道了",
 		stable: "穩定版",
 		changesInstantly: "變更會立即生效",
 		noDataYet: "尚無資料",
@@ -709,7 +769,7 @@ const TRANSLATIONS = {
 		status: "Статус",
 		active: "Включено",
 		inactive: "Выключено",
-		adsBlocked: "Заблокировано объявлений",
+		adsBlocked: "Заблокировано рекламы",
 		timeSaved: "Сэкономлено времени",
 		statistics: "Статистика",
 		last7Days: "За неделю",
@@ -727,6 +787,12 @@ const TRANSLATIONS = {
 			"Отправляет сигналы просмотра рекламы в Twitch, чтобы снизить вероятность обнаружения блокировщика.",
 		adSpoofingFootnote: "Отключите при возникновении проблем.",
 		adSpoofingGotIt: "Понятно",
+		autoplayBackup: "Резерв низкого качества",
+		autoplayBackupDesc:
+			"Переключается на резервный поток с более низким разрешением, когда нет источника высокого качества без рекламы. Обеспечивает плавное воспроизведение в 360p во время рекламы.",
+		autoplayBackupWarning:
+			"Отключение может вызвать чёрный экран или зависание видео во время рекламы на каналах, где все источники высокого качества содержат рекламу.",
+		autoplayBackupGotIt: "Понятно",
 		stable: "Стабильная",
 		changesInstantly: "Изменения применяются мгновенно",
 		noDataYet: "Пока нет данных",

--- a/src/scripts/bridge.ts
+++ b/src/scripts/bridge.ts
@@ -363,6 +363,7 @@ function postAchievementUnlock(id) {
 const bridgeState = {
 	enabled: true,
 	adSpoofingEnabled: true,
+	autoplayBackupEnabled: true,
 	storedAdsCount: 0,
 };
 const MAX_MESSAGE_DELTA = 50;
@@ -733,6 +734,9 @@ function broadcastState() {
 	sendToPage("ttvab-toggle-ad-spoofing", {
 		enabled: Boolean(bridgeState.adSpoofingEnabled),
 	});
+	sendToPage("ttvab-toggle-autoplay-backup", {
+		enabled: Boolean(bridgeState.autoplayBackupEnabled),
+	});
 	sendToPage("ttvab-init-count", {
 		count: normalizeCount(bridgeState.storedAdsCount),
 	});
@@ -820,7 +824,12 @@ function flushPendingCountersOnPageExit() {
 }
 
 chrome.storage.local.get(
-	["ttvAdblockEnabled", "ttvAdSpoofingEnabled", "ttvAdsBlocked"],
+	[
+		"ttvAdblockEnabled",
+		"ttvAdSpoofingEnabled",
+		"ttvAutoplayBackupEnabled",
+		"ttvAdsBlocked",
+	],
 	(result) => {
 		if (chrome.runtime.lastError) {
 			console.error(
@@ -831,6 +840,8 @@ chrome.storage.local.get(
 		const safeResult = result || {};
 		bridgeState.enabled = safeResult.ttvAdblockEnabled !== false;
 		bridgeState.adSpoofingEnabled = safeResult.ttvAdSpoofingEnabled !== false;
+		bridgeState.autoplayBackupEnabled =
+			safeResult.ttvAutoplayBackupEnabled !== false;
 		bridgeState.storedAdsCount = normalizeCount(safeResult.ttvAdsBlocked);
 
 		broadcastState();
@@ -851,10 +862,20 @@ chrome.storage.local.get(
 			if (changes.ttvAdSpoofingEnabled) {
 				const wasAdSpoofingEnabled = bridgeState.adSpoofingEnabled;
 				bridgeState.adSpoofingEnabled =
-					changes.ttvAdSpoofingEnabled.newValue === true;
+					changes.ttvAdSpoofingEnabled.newValue !== false;
 				if (bridgeState.adSpoofingEnabled !== wasAdSpoofingEnabled) {
 					sendToPage("ttvab-toggle-ad-spoofing", {
 						enabled: bridgeState.adSpoofingEnabled,
+					});
+				}
+			}
+			if (changes.ttvAutoplayBackupEnabled) {
+				const wasAutoplayBackupEnabled = bridgeState.autoplayBackupEnabled;
+				bridgeState.autoplayBackupEnabled =
+					changes.ttvAutoplayBackupEnabled.newValue !== false;
+				if (bridgeState.autoplayBackupEnabled !== wasAutoplayBackupEnabled) {
+					sendToPage("ttvab-toggle-autoplay-backup", {
+						enabled: bridgeState.autoplayBackupEnabled,
 					});
 				}
 			}

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -20,7 +20,7 @@ describe("_C constants", () => {
 	const C = () => g._C as Record<string, unknown>;
 
 	it("has valid version", () => {
-		expect(C().VERSION).toBe("9.0.8");
+		expect(C().VERSION).toBe("9.1.0");
 	});
 
 	it("has positive INTERNAL_VERSION", () => {


### PR DESCRIPTION
## Summary

Ports the Firefox v9.1.0 changes to Chrome: new low quality fallback toggle in popup, sub-toggle state sync, and automatic player reload when fallback is disabled while active.

## Changes

- **Popup toggle**: Low Quality Fallback switch with info tooltip and styled warning modal (11 locales)
- **Sub-toggle sync**: Ad spoofer and fallback toggles disable when master Ad Blocking is off
- **Auto-reload**: Disabling fallback while actively on autoplay backup triggers player reload to restore native quality
- **Core gating**: processor.ts skips autoplay in backup search when DisableAutoplayBackup is true
- **Worker bridge**: UpdateAutoplayBackupState handler, bridge storage watch and broadcast
- **Version bump**: 9.0.9 → 9.1.0

Refs #26, Refs #27